### PR TITLE
Adding the ability to define version from other than tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ For more information, reference the GitHub Help Documentation for [Creating a wo
 ### Inputs
 - `token`: The token to use for the GitHub API. default: ${{ github.token }}
 - `prerelease-branches`: A comma separated list of prerelease identifier suffixes to branch names that when merged a PR to will trigger a prerelease. default: ''
+- `current-version`: If the version is known, you can specify it with this. default: ''
 
 #### `prerelease-branches`
 A comma separated list of prerelease identifiers. It will output `should-publish = true` whenever a pull request is merged to a branch with a name which is a version with one of the given prerelease-branches identifers. It will also make sure to use the version in the branch name as part of the outputted `current-version` and use the latest version that is tagged that is equal to that prerelease version. For instance if a pull request is merged to the branch `2.0.0-alpha` and the repository has a tag named `2.0.0-alpha.20` `should-publish` should be `true`, `current-version` should be `2.0.0-alpha.20` and `release-type` should be prerelease. If there are no tags starting with `2.0.0-alpha` then that will be the `current-version` output.

--- a/Source/Version/DefinedVersionFinder.ts
+++ b/Source/Version/DefinedVersionFinder.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { SemVer } from 'semver';
+import { IFindCurrentVersion } from './IFindCurrentVersion';
+
+/**
+ * Represents an implementation of {@link IFindCurrentVersion} that uses a version defined from somewhere.
+ */
+export class DefinedVersionFinder implements IFindCurrentVersion {
+
+    /**
+     * Initializes a new instance of {@link DefinedVersionFinder}
+     * @param {string} version The defined version as a string
+     */
+    constructor(private readonly _version: string) { }
+
+    /** @inheritdoc */
+    find(prereleaseBranch: SemVer | undefined): Promise<SemVer> {
+        const promise = new Promise<SemVer>((resolve) => {
+            let currentVersion: SemVer;
+
+            if (this._version.length === 0) {
+                currentVersion = new SemVer('0.0.0');
+            } else {
+                currentVersion = new SemVer(this._version);
+            }
+
+            resolve(currentVersion);
+        });
+
+        return promise;
+    }
+}

--- a/Source/Version/index.ts
+++ b/Source/Version/index.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export { CurrentVersionFinder } from './CurrentVersionFinder';
+export { DefinedVersionFinder } from './DefinedVersionFinder';
+export { IFindCurrentVersion } from './IFindCurrentVersion';
+export { IVersionSorter } from './IVersionSorter';
+export { SemVerVersionSorter } from './SemVerVersionSorter';

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,10 @@ inputs:
     description: A comma-separated list of branch names that when merged a PR to will trigger a release.
     required: true
     default: ''
-
+  current-version:
+    description: If the version is known, you can specify it with this
+    required: false
+    default: ''
   
 outputs:
   should-publish:


### PR DESCRIPTION
This adds the possibility to establish context from a version defined with a different strategy than through tags.
When running with mono repos with multiple versioned artifacts within, tags won't work. 
Typically this would be used in conjunction with [this action](https://github.com/dolittle/read-version-from-file-action).
The result of this would be passed into this.