### PR TITLE
Fix releasing while prerelase is in progress

### DIFF
--- a/Source/CascadingBuildContextEstablisher.ts
+++ b/Source/CascadingBuildContextEstablisher.ts
@@ -5,13 +5,12 @@ import path from 'path';
 import { Context } from '@actions/github/lib/context';
 import { ILogger } from '@dolittle/github-actions.shared.logging';
 import { CascadingBuild } from '@dolittle/github-actions.shared.rudiments';
-import semver, { ReleaseType } from 'semver';
 import { BuildContext } from './BuildContext';
 import { ICanEstablishContext } from './ICanEstablishContext';
 import { IFindCurrentVersion } from './Version/IFindCurrentVersion';
 
 /**
- * Represents an implementation of {ICanEstablishContext}.
+ * Represents an implementation of {@link ICanEstablishContext}.
  *
  * @export
  * @class CascadingContextEstablisher
@@ -20,13 +19,14 @@ import { IFindCurrentVersion } from './Version/IFindCurrentVersion';
 export class CascadingContextEstablisher implements ICanEstablishContext {
 
     /**
-     * Creates an instance of CascadingContextEstablisher.
-     * @param {InstanceType<typeof GitHub>} _github The github REST api.
+     * Initializes a new instance of {@link CascadingContextEstablisher}
+     * @param {IFindCurrentVersion} _currentVersionFinder The current version finder to use for finding the current version.
+     * @param {ILogger} _logger The logger to use for logging.
      */
     constructor(
         private readonly _currentVersionFinder: IFindCurrentVersion,
-        private readonly _logger: ILogger) {
-        }
+        private readonly _logger: ILogger) { }
+
     /**
      * @inheritdoc
      */

--- a/Source/ContextEstablishers.ts
+++ b/Source/ContextEstablishers.ts
@@ -7,7 +7,7 @@ import { IContextEstablishers } from './IContextEstablishers';
 import { ICanEstablishContext } from './ICanEstablishContext';
 
 /**
- * Represents an implementation of {IContextEstablishers}.
+ * Represents an implementation of {@link IContextEstablishers}.
  *
  * @export
  * @class ContextEstablishers
@@ -16,10 +16,17 @@ import { ICanEstablishContext } from './ICanEstablishContext';
 export class ContextEstablishers implements IContextEstablishers {
     private readonly _establishers: ICanEstablishContext[];
 
+    /**
+     * Initializes a new instance of {@link ContextEstablishers}
+     * @param {ICanEstablishContext[]} establishers The implementations of context establishers to use.
+     */
     constructor(...establishers: ICanEstablishContext[]) {
         this._establishers = establishers;
     }
 
+    /**
+     * @inheritdoc
+     */
     establishFrom(context: Context): Promise<BuildContext> | Promise<undefined> {
         const establisher = this.getEstablisherFor(context);
         return establisher?.establish(context) ?? Promise.resolve(undefined);

--- a/Source/IContextEstablishers.ts
+++ b/Source/IContextEstablishers.ts
@@ -5,7 +5,7 @@ import { Context } from '@actions/github/lib/context';
 import { BuildContext } from './BuildContext';
 
 /**
- * Defines a system that knows about {ICanEstablishContext} implementations.
+ * Defines a system that knows about {@link ICanEstablishContext} implementations.
  *
  * @export
  * @interface IContextEstablishers
@@ -14,11 +14,11 @@ import { BuildContext } from './BuildContext';
 export interface IContextEstablishers {
 
     /**
-     * Establishes a {BuildContext} from the given github {Context}.
+     * Establishes a {@link BuildContext} from the given github {@link Context}.
      *
-     * @param {Context} context The github context.
-     * @param {InstanceType<typeof GitHub>} github The github REST api.
-     * @returns {Promise<BuildContext>} A {Promise} that, when resolved, returns the {BuildContext}.
+     * @param {Context} context The GitHub context.
+     * @param {InstanceType<typeof GitHub>} github The GitHub REST api.
+     * @returns {Promise<BuildContext>} A {@link Promise} that, when resolved, returns the {@link BuildContext}.
      */
     establishFrom(context: Context): Promise<BuildContext> | Promise<undefined>;
 }

--- a/Source/MergedPullRequestContextEstablisher.ts
+++ b/Source/MergedPullRequestContextEstablisher.ts
@@ -18,7 +18,7 @@ const nonPrereleaseLabels = [
 ];
 
 /**
- * Represents an implementation of {ICanEstablishContext}.
+ * Represents an implementation of {@link ICanEstablishContext}.
  *
  * @export
  * @class MergedPullRequestContextEstablisher
@@ -27,8 +27,13 @@ const nonPrereleaseLabels = [
 export class MergedPullRequestContextEstablisher implements ICanEstablishContext {
 
     /**
-     * Creates an instance of MergedPullRequestContextEstablisher.
+     * Initializes a new instance of {@link MergedPullRequestContextEstablisher}
+     * @param {string[]} _prereleaseBranches A list of branches that should be considered as pre-release branches.
+     * @param {string} _environmentBranch An environment to use for prereleases.
+     * @param {IReleaseTypeExtractor} _releaseTypeExtractor The release type extractor to use for extracting the release type from Pull Request labels.
+     * @param {IFindCurrentVersion} _currentVersionFinder The current version finder to use for finding the current version.
      * @param {InstanceType<typeof GitHub>} _github The github REST api.
+     * @param {ILogger} _logger The logger to use for logging.
      */
     constructor(
         private readonly _prereleaseBranches: string[],
@@ -38,6 +43,7 @@ export class MergedPullRequestContextEstablisher implements ICanEstablishContext
         private readonly _github: InstanceType<typeof GitHub>,
         private readonly _logger: ILogger) {
     }
+
     /**
      * @inheritdoc
      */
@@ -81,8 +87,8 @@ export class MergedPullRequestContextEstablisher implements ICanEstablishContext
         const labels = mergedPr?.labels.map(_ => _.name);
         this._logger.info(`PR has the following labels: '${labels}'`);
 
-        const releaseType = prereleaseBranch !== undefined ?
-            'prerelease'
+        const releaseType = prereleaseBranch !== undefined
+            ? 'prerelease'
             : this._releaseTypeExtractor.extract(labels);
         if (releaseType === undefined) {
             this._logger.info('Found no release type label on pull request');

--- a/Source/ReleaseType/ReleaseTypeExtractor.ts
+++ b/Source/ReleaseType/ReleaseTypeExtractor.ts
@@ -25,8 +25,8 @@ const prioritizedReleaseTypes: ReleaseType[] = [
 export class ReleaseTypeExtractor implements IReleaseTypeExtractor {
 
     /**
-     * Instantiating an instance of {ReleaseTypeExtractor}.
-     * @param {ILogger} _logger
+     * Creates an instance of ReleaseTypeExtractor.
+     * @param {ILogger} _logger The logger to use for logging.
      */
     constructor(private _logger: ILogger) {}
 
@@ -43,5 +43,4 @@ export class ReleaseTypeExtractor implements IReleaseTypeExtractor {
         }
         return undefined;
     }
-
 }

--- a/Source/Version/CurrentVersionFinder.ts
+++ b/Source/Version/CurrentVersionFinder.ts
@@ -56,7 +56,7 @@ export class CurrentVersionFinder implements IFindCurrentVersion {
             return versions.filter(_ => _.prerelease.length === 0);
         } else {
             this._logger.debug(`Filtering only versions matching prerelease ${prereleaseBranch}`);
-            return versions.filter(_ => _.compareMain(prereleaseBranch) === 0);
+            return versions.filter(_ => _.compareMain(prereleaseBranch) === 0 && _.prerelease.length > 0 && _.prerelease[0] === prereleaseBranch.prerelease[0]);
         }
     }
 

--- a/Source/Version/CurrentVersionFinder.ts
+++ b/Source/Version/CurrentVersionFinder.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import semver, { SemVer } from 'semver';
+import { SemVer } from 'semver';
 import { ILogger } from '@dolittle/github-actions.shared.logging';
 import { IFindCurrentVersion } from './IFindCurrentVersion';
 import { IVersionSorter } from './IVersionSorter';
@@ -32,44 +32,37 @@ export class CurrentVersionFinder implements IFindCurrentVersion {
      */
     async find(prereleaseBranch: SemVer | undefined): Promise<SemVer> {
         const versions = await this._versionFetcher.fetchPreviouslyReleasedVersions();
-        if (!versions || versions.length === 0) {
-            const defaultVersion = new SemVer('0.0.0');
+        const sorted = this._versionSorter.sort(versions, true);
+
+        this._logger.debug(`All version tags: [\n${sorted.join(',\n')}\n]`);
+
+        const filtered = this._filterApplicableVersions(sorted, prereleaseBranch);
+        this._logger.debug(`Filtered version tags: [\n${filtered.join(',\n')}\n]`);
+
+        if (filtered.length === 0) {
+            const defaultVersion = this._getDefaultVersion(prereleaseBranch);
             this._logger.info(`No version tags. Defaulting to version ${defaultVersion.version}`);
             return defaultVersion;
         }
 
-        this._logger.debug(`Version tags: [\n${versions.join(',\n')}\n]`);
-
-        const currentVersion = this._findGreatestMatchingVersion(this._versionSorter.sort(versions, true), prereleaseBranch);
+        const currentVersion = filtered[0];
         this._logger.info(`Current version '${currentVersion}'`);
         return currentVersion;
     }
 
-    private _findGreatestMatchingVersion(versionsDescending: SemVer[], prereleaseBranch: SemVer | undefined) {
+    private _filterApplicableVersions(versions: SemVer[], prereleaseBranch: SemVer | undefined) {
         if (prereleaseBranch === undefined) {
-            const greatestVersion = versionsDescending[0];
-            this._logger.debug(`Not searching for prerelease. Returning greatest version ${greatestVersion}`);
-            return greatestVersion;
+            this._logger.debug('Filtering only non-prerelease versions');
+            return versions.filter(_ => _.prerelease.length === 0);
+        } else {
+            this._logger.debug(`Filtering only versions matching prerelease ${prereleaseBranch}`);
+            return versions.filter(_ => _.compareMain(prereleaseBranch) === 0);
         }
+    }
 
-        this._logger.debug(`Searching for version with the greatest build number of prerelease ${prereleaseBranch}`);
-        for (const version of versionsDescending) {
-            this._logger.debug(`Checking version ${version}`);
-            if (semver.gt(prereleaseBranch, version)) {
-                this._logger.debug(`${prereleaseBranch} is greater than ${version}. Defaulting to ${prereleaseBranch}`);
-                return prereleaseBranch;
-            }
-            const versionPrerelease = version.prerelease;
-            if (versionPrerelease === null || versionPrerelease.length === 0)
-            {
-                this._logger.debug(`${version} is not a prerelease version. Skipping`);
-                continue;
-            }
-            if (prereleaseBranch.compareMain(version) === 0) {
-                this._logger.debug(`${prereleaseBranch} and ${version} match`);
-                return version;
-            }
-        }
-        return prereleaseBranch;
+    private _getDefaultVersion(prereleaseBranch: SemVer | undefined): SemVer {
+        return prereleaseBranch === undefined
+            ? new SemVer('0.0.0')
+            : prereleaseBranch;
     }
 }

--- a/Source/Version/CurrentVersionFinder.ts
+++ b/Source/Version/CurrentVersionFinder.ts
@@ -8,20 +8,23 @@ import { IVersionSorter } from './IVersionSorter';
 import { IVersionFetcher } from './IVersionFetcher';
 
 /**
- * Represents an implementation of {ICanGetLatestVersion} that can get the latest version from Github
+ * Represents an implementation of {@link IFindCurrentVersion} that can get the latest version.
  *
  * @export
- * @class GithubLatestVersionFinder
- * @implements {ICanGetLatestVersion}
+ * @class CurrentVersionFinder
+ * @implements {IFindCurrentVersion}
  */
 export class CurrentVersionFinder implements IFindCurrentVersion {
 
     /**
-     * Instantiates an instance of {GithubVersionTags}.
+     * Initializes a new instance of {@link CurrentVersionFinder}
+     * @param {IVersionFetcher} _versionFetcher The version fetcher to use to fetch all released versions.
+     * @param {IVersionSorter} _versionSorter The version sorter to use for sorting versions.
+     * @param {ILogger} _logger The logger to use for logging.
      */
     constructor(
-        private readonly _versionSorter: IVersionSorter,
         private readonly _versionFetcher: IVersionFetcher,
+        private readonly _versionSorter: IVersionSorter,
         private readonly _logger: ILogger) {}
 
     /**
@@ -35,9 +38,7 @@ export class CurrentVersionFinder implements IFindCurrentVersion {
             return defaultVersion;
         }
 
-        this._logger.debug(`Version tags: [
-${versions.join(',\n')}
-]`);
+        this._logger.debug(`Version tags: [\n${versions.join(',\n')}\n]`);
 
         const currentVersion = this._findGreatestMatchingVersion(this._versionSorter.sort(versions, true), prereleaseBranch);
         this._logger.info(`Current version '${currentVersion}'`);
@@ -51,7 +52,6 @@ ${versions.join(',\n')}
             return greatestVersion;
         }
 
-        const prereleaseId = prereleaseBranch.prerelease[0];
         this._logger.debug(`Searching for version with the greatest build number of prerelease ${prereleaseBranch}`);
         for (const version of versionsDescending) {
             this._logger.debug(`Checking version ${version}`);

--- a/Source/Version/DefinedVersionFinder.ts
+++ b/Source/Version/DefinedVersionFinder.ts
@@ -16,7 +16,7 @@ export class DefinedVersionFinder implements IFindCurrentVersion {
     constructor(private readonly _version: string) { }
 
     /** @inheritdoc */
-    find(prereleaseBranch: SemVer | undefined): Promise<SemVer> {
+    find(): Promise<SemVer> {
         const promise = new Promise<SemVer>((resolve) => {
             let currentVersion: SemVer;
 
@@ -32,5 +32,3 @@ export class DefinedVersionFinder implements IFindCurrentVersion {
         return promise;
     }
 }
-
-

--- a/Source/Version/GitHubTagsVersionFetcher.ts
+++ b/Source/Version/GitHubTagsVersionFetcher.ts
@@ -8,7 +8,7 @@ import { GitHub } from '@actions/github/lib/utils';
 import { IVersionFetcher } from './IVersionFetcher';
 
 /**
- * Represents an implementation of {IVersionFetcher} that can versions from GitHhub tags
+ * Represents an implementation of {@link IVersionFetcher} that can versions from GitHhub tags
  *
  * @export
  * @class GitHubTagsVersionFetcher
@@ -17,12 +17,15 @@ import { IVersionFetcher } from './IVersionFetcher';
 export class GitHubTagsVersionFetcher implements IVersionFetcher {
 
     /**
-     * Instantiates an instance of {GitHubTagsVersionFetcher}.
+     * Initializes a new instance of {@link GitHubTagsVersionFetcher}
+     * @param {Context} _context The GitHub context.
+     * @param {InstanceType<typeof GitHub>} github The GitHub REST api client to use for fetching tags.
+     * @param {ILogger} _logger The logger to use for logging.
      */
-     constructor(
+    constructor(
         private readonly _context: Context,
         private readonly _github: InstanceType<typeof GitHub>,
-        private readonly _logger: ILogger) {}
+        private readonly _logger: ILogger) { }
 
     async fetchPreviouslyReleasedVersions(): Promise<SemVer[]> {
         const {owner, repo} = this._context.repo;

--- a/Source/Version/GitHubTagsVersionFetcher.ts
+++ b/Source/Version/GitHubTagsVersionFetcher.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import semver, { SemVer } from 'semver';
+import { ILogger } from '@dolittle/github-actions.shared.logging';
+import { Context } from '@actions/github/lib/context';
+import { GitHub } from '@actions/github/lib/utils';
+import { IVersionFetcher } from './IVersionFetcher';
+
+/**
+ * Represents an implementation of {IVersionFetcher} that can versions from GitHhub tags
+ *
+ * @export
+ * @class GitHubTagsVersionFetcher
+ * @implements {IVersionFetcher}
+ */
+export class GitHubTagsVersionFetcher implements IVersionFetcher {
+
+    /**
+     * Instantiates an instance of {GitHubTagsVersionFetcher}.
+     */
+     constructor(
+        private readonly _context: Context,
+        private readonly _github: InstanceType<typeof GitHub>,
+        private readonly _logger: ILogger) {}
+
+    async fetchPreviouslyReleasedVersions(): Promise<SemVer[]> {
+        const {owner, repo} = this._context.repo;
+        this._logger.debug(`Getting version tags from github.com/${owner}/${repo}`);
+
+        const versions = await this._github.paginate(
+            this._github.repos.listTags,
+            {owner, repo},
+            response => response.data
+                                    .filter(tag => semver.valid(tag.name))
+                                    .map(_ => _.name!));
+
+        return versions.map(_ => semver.parse(_)!);
+    }
+}

--- a/Source/Version/IVersionFetcher.ts
+++ b/Source/Version/IVersionFetcher.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { SemVer } from 'semver';
+
+/**
+ * Defines a system that can fetch versions.
+ *
+ * @export
+ * @interface IVersionFetcher
+ */
+export interface IVersionFetcher {
+
+    /**
+     * Fetches all previously released versions.
+     *
+     * @returns {SemVer[] | Promise<SemVer[]>}
+     */
+    fetchPreviouslyReleasedVersions(): SemVer[] | Promise<SemVer[]>;
+}

--- a/Source/Version/IVersionSorter.ts
+++ b/Source/Version/IVersionSorter.ts
@@ -14,8 +14,8 @@ export interface IVersionSorter {
     /**
      * Sorts a list of versions.
      *
-     * @param {SemVer[]} versions
-     * @param {boolean} [descending]
+     * @param {SemVer[]} versions The versions to sort.
+     * @param {boolean} [descending] True to sort versions in descending order (default), or false to sort versions in ascending order.
      * @returns {SemVer[]}
      */
     sort(versions: SemVer[], descending?: boolean): SemVer[]

--- a/Source/Version/SemVerVersionSorter.ts
+++ b/Source/Version/SemVerVersionSorter.ts
@@ -6,7 +6,7 @@ import semver, { SemVer } from 'semver';
 import { IVersionSorter } from './IVersionSorter';
 
 /**
- * Represents an implementation of {IVersionSorter} that can sort versions according to SemVer
+ * Represents an implementation of {@link IVersionSorter} that can sort versions according to SemVer
  *
  * @export
  * @class SemVerVersionSorter
@@ -15,10 +15,10 @@ import { IVersionSorter } from './IVersionSorter';
 export class SemVerVersionSorter implements IVersionSorter {
 
     /**
-     * Instantiates an instance of {SemVerVersionSorter}.
-     * @param {ILogger} _logger
+     * Initializes a new instance of {@link SemVerVersionSorter}
+     * @param {ILogger} _logger The logger to use for logging.
      */
-    constructor(private _logger: ILogger ) {}
+    constructor(private _logger: ILogger) {}
 
     /**
      * @inheritdoc
@@ -31,5 +31,4 @@ export class SemVerVersionSorter implements IVersionSorter {
         });
         return descending ? semver.rsort(versions) : semver.sort(versions);
     }
-
 }

--- a/Source/Version/VersionFromFileVersionFinder.ts
+++ b/Source/Version/VersionFromFileVersionFinder.ts
@@ -15,11 +15,14 @@ export class VersionFromFileVersionFinder implements IFindCurrentVersion {
     /**
      * Initializes a new instance of {@link VersionFromFileVersionFinder}.
      * @param {string} _file Path to JSON file to read from.
+     * @param {ILogger} _logger The logger to use for logging.
      */
-    constructor(private readonly _file: string, private readonly _logger: ILogger) { }
+    constructor(
+        private readonly _file: string,
+        private readonly _logger: ILogger) { }
 
     /** @inheritdoc */
-    async find(prereleaseBranch: SemVer | undefined): Promise<SemVer> {
+    async find(): Promise<SemVer> {
         const defaultVersion = new SemVer('1.0.0');
         try {
             const absolutePath = path.resolve(this._file);

--- a/Source/Version/for_CurrentVersionFinder/given/a_version_finder.ts
+++ b/Source/Version/for_CurrentVersionFinder/given/a_version_finder.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { SemVer } from 'semver';
+import * as sinon from 'ts-sinon';
+import { NullLogger } from '@dolittle/github-actions.shared.logging';
+import { IVersionSorter } from '../../IVersionSorter';
+import { CurrentVersionFinder } from '../../CurrentVersionFinder';
+import { IVersionFetcher } from '../../IVersionFetcher';
+
+export class a_version_finder {
+    static with_sorted_versions(...versions: string[]): CurrentVersionFinder {
+        const semvers = versions.map(_ => new SemVer(_));
+
+        const fetcher = sinon.stubInterface<IVersionFetcher>({
+            fetchPreviouslyReleasedVersions: semvers,
+        });
+
+        const sorter = sinon.stubInterface<IVersionSorter>({
+            sort: semvers,
+        });
+
+        return new CurrentVersionFinder(fetcher, sorter, new NullLogger());
+    }
+}

--- a/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_are_no_matching_prereleases.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_are_no_matching_prereleases.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { SemVer } from 'semver';
+import { a_version_finder } from '../../given/a_version_finder';
+
+describe('when finding with a prerelease and there are no matching prereleases', () => {
+    const finder = a_version_finder.with_sorted_versions('1.2.0', '1.2.0-alpha', '1.0.0', '1.0.0-beta.1', '1.0.0-beta', '1.0.0-alpha', '0.9.0');
+    const prerelease = new SemVer('1.1.0-alpha');
+
+    const result = finder.find(prerelease).then(_ => _.format());
+
+    it('should return the specified prerelease', () => result.should.eventually.equal('1.1.0-alpha'));
+});

--- a/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_are_no_versions.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_are_no_versions.ts
@@ -10,5 +10,5 @@ describe('when finding with a prerelease and there are no versions', () => {
 
     const result = finder.find(prerelease).then(_ => _.format());
 
-    it('should return the initial version', () => result.should.eventually.equal('0.0.0'));
+    it('should return the specified prerelease', () => result.should.eventually.equal('1.1.0-alpha'));
 });

--- a/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_are_no_versions.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_are_no_versions.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { SemVer } from 'semver';
+import { a_version_finder } from '../../given/a_version_finder';
+
+describe('when finding with a prerelease and there are no versions', () => {
+    const finder = a_version_finder.with_sorted_versions();
+    const prerelease = new SemVer('1.1.0-alpha');
+
+    const result = finder.find(prerelease).then(_ => _.format());
+
+    it('should return the initial version', () => result.should.eventually.equal('0.0.0'));
+});

--- a/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_are_two_matching_prereleases.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_are_two_matching_prereleases.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { SemVer } from 'semver';
+import { a_version_finder } from '../../given/a_version_finder';
+
+describe('when finding with a prerelease and there are two matching prereleases', () => {
+    const finder = a_version_finder.with_sorted_versions('1.2.0', '1.2.0-alpha', '1.1.0-alpha.1', '1.1.0-alpha', '1.0.0', '0.9.0');
+    const prerelease = new SemVer('1.1.0-alpha');
+
+    const result = finder.find(prerelease).then(_ => _.format());
+
+    it('should return the specified prerelease', () => result.should.eventually.equal('1.1.0-alpha.1'));
+});

--- a/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_is_a_newer_prerelease_for_same_version.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_is_a_newer_prerelease_for_same_version.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { SemVer } from 'semver';
+import { a_version_finder } from '../../given/a_version_finder';
+
+describe('when finding with a prerelease and there is a newer prerelease for the same version', () => {
+    const finder = a_version_finder.with_sorted_versions('1.3.0', '1.2.0-beta', '1.2.0-alpha.1', '1.2.0-alpha', '1.1.0');
+    const prerelease = new SemVer('1.2.0-alpha');
+
+    const result = finder.find(prerelease).then(_ => _.format());
+
+    it('should return the specified prerelease', () => result.should.eventually.equal('1.2.0-alpha.1'));
+});

--- a/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_is_one_matching_prerelease.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_is_one_matching_prerelease.ts
@@ -4,7 +4,7 @@
 import { SemVer } from 'semver';
 import { a_version_finder } from '../../given/a_version_finder';
 
-describe('when finding with a prerelease and is one matching prereleases', () => {
+describe('when finding with a prerelease and is one matching prerelease', () => {
     const finder = a_version_finder.with_sorted_versions('1.3.0-beta.1', '1.2.0-beta.2', '1.2.0-beta.1', '1.2.0-beta', '1.1.0');
     const prerelease = new SemVer('1.3.0-beta');
 

--- a/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_is_one_matching_prerelease.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/with_a_prerelease/and_there_is_one_matching_prerelease.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { SemVer } from 'semver';
+import { a_version_finder } from '../../given/a_version_finder';
+
+describe('when finding with a prerelease and is one matching prereleases', () => {
+    const finder = a_version_finder.with_sorted_versions('1.3.0-beta.1', '1.2.0-beta.2', '1.2.0-beta.1', '1.2.0-beta', '1.1.0');
+    const prerelease = new SemVer('1.3.0-beta');
+
+    const result = finder.find(prerelease).then(_ => _.format());
+
+    it('should return the specified prerelease', () => result.should.eventually.equal('1.3.0-beta.1'));
+});

--- a/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_are_no_versions.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_are_no_versions.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { a_version_finder } from '../../given/a_version_finder';
+
+describe('when finding without a prerelease and there are no versions', () => {
+    const finder = a_version_finder.with_sorted_versions();
+
+    const result = finder.find(undefined).then(_ => _.format());
+
+    it('should return the initial version', () => result.should.eventually.equal('0.0.0'));
+});

--- a/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_are_three_versions.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_are_three_versions.ts
@@ -8,5 +8,5 @@ describe('when finding without a prerelease there are three versions', () => {
 
     const result = finder.find(undefined).then(_ => _.format());
 
-    it('should return the first one', () => result.should.eventually.equal('1.0.0'));
+    it('should return the last version', () => result.should.eventually.equal('1.0.0'));
 });

--- a/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_are_three_versions.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_are_three_versions.ts
@@ -3,7 +3,7 @@
 
 import { a_version_finder } from '../../given/a_version_finder';
 
-describe('when finding without a prerelease there is three versions', () => {
+describe('when finding without a prerelease there are three versions', () => {
     const finder = a_version_finder.with_sorted_versions('1.0.0', '0.9.1', '0.0.0');
 
     const result = finder.find(undefined).then(_ => _.format());

--- a/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_is_a_new_prerelease_underway.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_is_a_new_prerelease_underway.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { a_version_finder } from '../../given/a_version_finder';
+
+describe('when finding without a prerelease and there is a new prerelease underway', () => {
+    const finder = a_version_finder.with_sorted_versions('2.0.0-lightspeed','1.1.0','1.0.1','1.0.0');
+
+    const result = finder.find(undefined).then(_ => _.format());
+
+    it('should return the last non-prerelease', () => result.should.eventually.equal('1.1.0'));
+});

--- a/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_is_a_prerelease_of_the_last_version.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_is_a_prerelease_of_the_last_version.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { a_version_finder } from '../../given/a_version_finder';
+
+describe('when finding without a prerelease and there is a prerelease of the last version', () => {
+    const finder = a_version_finder.with_sorted_versions('1.0.0', '1.0.0-alpha', '0.9.1', '0.0.0');
+
+    const result = finder.find(undefined).then(_ => _.format());
+
+    it('should return the the last non-prerelease version', () => result.should.eventually.equal('1.0.0'));
+});

--- a/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_is_an_older_prerelease.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_is_an_older_prerelease.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { a_version_finder } from '../../given/a_version_finder';
+
+describe('when finding without a prerelease and there is an older prerelease', () => {
+    const finder = a_version_finder.with_sorted_versions('1.0.0', '0.9.1', '0.9.1-gamma', '0.0.0');
+
+    const result = finder.find(undefined).then(_ => _.format());
+
+    it('should return the the last non-prerelease version', () => result.should.eventually.equal('1.0.0'));
+});

--- a/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_is_three_versions.ts
+++ b/Source/Version/for_CurrentVersionFinder/when_finding/without_a_prerelease/and_there_is_three_versions.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { a_version_finder } from '../../given/a_version_finder';
+
+describe('when finding without a prerelease there is three versions', () => {
+    const finder = a_version_finder.with_sorted_versions('1.0.0', '0.9.1', '0.0.0');
+
+    const result = finder.find(undefined).then(_ => _.format());
+
+    it('should return the first one', () => result.should.eventually.equal('1.0.0'));
+});

--- a/Source/Version/index.ts
+++ b/Source/Version/index.ts
@@ -3,6 +3,9 @@
 
 export { CurrentVersionFinder } from './CurrentVersionFinder';
 export { DefinedVersionFinder } from './DefinedVersionFinder';
+export { GitHubTagsVersionFetcher } from './GitHubTagsVersionFetcher';
 export { IFindCurrentVersion } from './IFindCurrentVersion';
+export { IVersionFetcher } from './IVersionFetcher';
 export { IVersionSorter } from './IVersionSorter';
 export { SemVerVersionSorter } from './SemVerVersionSorter';
+export { VersionFromFileVersionFinder } from './VersionFromFileVersionFinder';

--- a/Source/action.ts
+++ b/Source/action.ts
@@ -52,8 +52,8 @@ export async function run() {
         } else {
             logger.info('Using tag strategy for finding version');
             currentVersionFinder = new CurrentVersionFinder(
-                new SemVerVersionSorter(logger),
                 new GitHubTagsVersionFetcher(context, octokit, logger),
+                new SemVerVersionSorter(logger),
                 logger);
         }
 

--- a/Source/action.ts
+++ b/Source/action.ts
@@ -18,6 +18,7 @@ import { CascadingContextEstablisher } from './CascadingBuildContextEstablisher'
 import { MergedPullRequestContextEstablisher } from './MergedPullRequestContextEstablisher';
 import { BuildContext } from './BuildContext';
 import { VersionFromFileVersionFinder } from './Version/VersionFromFileVersionFinder';
+import { GitHubTagsVersionFetcher } from './Version/GitHubTagsVersionFetcher';
 
 const logger = new Logger();
 
@@ -52,8 +53,7 @@ export async function run() {
             logger.info('Using tag strategy for finding version');
             currentVersionFinder = new CurrentVersionFinder(
                 new SemVerVersionSorter(logger),
-                context,
-                octokit,
+                new GitHubTagsVersionFetcher(context, octokit, logger),
                 logger);
         }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "@dolittle/typescript.build": "^5.3.6",
     "@types/semver": "^7.2.0",
     "@zeit/ncc": "^0.22.3",
-    "del-cli": "^3.0.1"
+    "del-cli": "^3.0.1",
+    "ts-sinon": "^2.0.1"
   },
   "dependencies": {
     "@actions/core": "^1.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,6 +236,13 @@
   dependencies:
     type-detect "4.0.8"
 
+"@sinonjs/commons@^1.8.1":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
+  integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
+  dependencies:
+    type-detect "4.0.8"
+
 "@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
@@ -255,6 +262,15 @@
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.0.3.tgz#86f21bdb3d52480faf0892a480c9906aa5a52938"
   integrity sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/samsam@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.3.1.tgz#375a45fe6ed4e92fca2fb920e007c48232a6507f"
+  integrity sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==
   dependencies:
     "@sinonjs/commons" "^1.6.0"
     lodash.get "^4.4.2"
@@ -315,6 +331,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.12.tgz#9c72e865380a7dc99999ea0ef20fc9635b503d20"
   integrity sha512-zWz/8NEPxoXNT9YyF2osqyA9WjssZukYpgI4UYZpOjcyqwIUqWGkcCionaEb9Ki+FULyPyvNFpg/329Kd2/pbw==
 
+"@types/node@^14.6.1":
+  version "14.14.45"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.45.tgz#ec2dfb5566ff814d061aef7e141575aedba245cf"
+  integrity sha512-DssMqTV9UnnoxDWu959sDLZzfvqCF0qDNRjaWeYSui9xkFe61kKo4l1TWNTQONpuXEm+gLMRvdlzvNHBamzmEw==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -335,10 +356,25 @@
     "@types/chai" "*"
     "@types/sinon" "*"
 
+"@types/sinon-chai@^3.2.4":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@types/sinon-chai/-/sinon-chai-3.2.5.tgz#df21ae57b10757da0b26f512145c065f2ad45c48"
+  integrity sha512-bKQqIpew7mmIGNRlxW6Zli/QVyc3zikpGzCa797B/tRnD9OtHvZ/ts8sYXV+Ilj9u3QRaUEM8xrjgd1gwm1BpQ==
+  dependencies:
+    "@types/chai" "*"
+    "@types/sinon" "*"
+
 "@types/sinon@*", "@types/sinon@^9.0.0":
   version "9.0.4"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.4.tgz#e934f904606632287a6e7f7ab0ce3f08a0dad4b1"
   integrity sha512-sJmb32asJZY6Z2u09bl0G2wglSxDlROlAejCjsnor+LzBMz17gu8IU7vKC/vWDnv9zEq2wqADHVXFjf4eE8Gdw==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
+
+"@types/sinon@^9.0.5":
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.11.tgz#7af202dda5253a847b511c929d8b6dda170562eb"
+  integrity sha512-PwP4UY33SeeVKodNE37ZlOsR9cReypbMJOhZ7BVE0lB+Hix3efCOxiJWiE5Ia+yL9Cn2Ch72EjFTRze8RZsNtg==
   dependencies:
     "@types/sinonjs__fake-timers" "*"
 
@@ -2996,6 +3032,17 @@ nise@^4.0.1:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
+nise@^4.0.4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-4.1.0.tgz#8fb75a26e90b99202fa1e63f448f58efbcdedaf6"
+  integrity sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/fake-timers" "^6.0.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
+
 node-environment-flags@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.5.tgz#fa930275f5bf5dae188d6192b24b4c8bbac3d76a"
@@ -3833,6 +3880,18 @@ sinon@^9.0.2:
     nise "^4.0.1"
     supports-color "^7.1.0"
 
+sinon@^9.0.3:
+  version "9.2.4"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.4.tgz#e55af4d3b174a4443a8762fa8421c2976683752b"
+  integrity sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==
+  dependencies:
+    "@sinonjs/commons" "^1.8.1"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/samsam" "^5.3.1"
+    diff "^4.0.2"
+    nise "^4.0.4"
+    supports-color "^7.1.0"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -4246,6 +4305,16 @@ trim-newlines@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
   integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
+
+ts-sinon@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ts-sinon/-/ts-sinon-2.0.1.tgz#77dd909ca85c6062990b2117554a03a74bfd132c"
+  integrity sha512-uI5huDCY6Gw6Yczmyd/Jcu8gZZYtWO0HakPShvDmlrgcywLyFZ7lgWt1y+gd/x79ReHh+rhMAJkhQkGRnPNikw==
+  dependencies:
+    "@types/node" "^14.6.1"
+    "@types/sinon" "^9.0.5"
+    "@types/sinon-chai" "^3.2.4"
+    sinon "^9.0.3"
 
 tslib@^1.10.0, tslib@^1.8.1:
   version "1.13.0"


### PR DESCRIPTION
## Summary

The main purpose of this PR was to fix an issue we were having when we were releasing fixes while working on a new prerelease in a branch. So for example say we were working on `5.6.0-embeddings` while the latest release was on `5.5.2`. When we merged in a _patch_ to master, the expected new version should be `5.5.3`, but was `5.6.0`.

Factored out the fetching of versions from `CurrentVersionFinder` so that we can write some specs for it, wrote specs, and fixed the implementation. Also cleaned up some documentation to make it all the same (a few different styles floating around), and removed some unused code.

### Added

- `IVersionFetcher` and implementation `GitHubTagsVersionFetcher` using existing code.
- Specifications for `CurrentVersionFinder`

### Fixed

- `CurrentVersionFinder` so that it disregards running prereleases when pulling in a normal release. Also found some other potential small issues that we have not encountered.
