### PR TITLE
Trim after splitting prereleases input to ignore spaces around commas.

### DIFF
--- a/Source/action.ts
+++ b/Source/action.ts
@@ -26,7 +26,7 @@ run();
 export async function run() {
     try {
         const token = getInput('token', { required: true });
-        const prereleaseBranches = getInput('prerelease-branches', { required: false })?.split(',') ?? [];
+        const prereleaseBranches = getInput('prerelease-branches', { required: false })?.split(',').map(_ => _.trim()) ?? [];
         const currentVersion = getInput('current-version', { required: false }) ?? '';
         const versionFile = getInput('version-file', { required: false }) ?? '';
         const environmentBranch = getInput('environment-branch', { required: false });


### PR DESCRIPTION
## Summary

Trims the spaces around prerelease branch names after splitting on comma to allow specifying:
```yaml
     - name: Establish context
        id: context
        uses: dolittle/establish-context-action@v2
        with:
          prerelease-branches: legolas, gandalf
```
instead of:
```yaml
     - name: Establish context
        id: context
        uses: dolittle/establish-context-action@v2
        with:
          prerelease-branches: legolas,gandalf
```

### Fixed

- Trim spaces around prerelease branch names